### PR TITLE
Heading indeling #Issue 16

### DIFF
--- a/src/lib/components/system-status.svelte
+++ b/src/lib/components/system-status.svelte
@@ -25,30 +25,30 @@
 	<h2>System statuses</h2>
 	<table>
 		<tr>
-			<td class="dot">
+			<td>
 				<div class="pulse-container">
 					<div class="status-pulse">
 						<div class="pulse-marker green" />
-						<h3>In operation</h3>
+						<p>In operation</p>
 					</div>
 				</div>
 			</td>
 			<td class="amount">
-				<h4>{operational.length} interceptors</h4>
+				<p>{operational.length} interceptors</p>
 			</td>
 		</tr>
 
 		<tr>
-			<td class="dot">
+			<td>
 				<div class="pulse-container">
 					<div class="status-pulse">
 						<div class="pulse-marker green" />
-						<h3>Harvesting</h3>
+						<p>Harvesting</p>
 					</div>
 				</div>
 			</td>
 			<td class="amount">
-				<h4>1 ocean system</h4>
+				<p>1 ocean system</p>
 			</td>
 		</tr>
 
@@ -57,12 +57,12 @@
 				<div class="pulse-container">
 					<div class="status-pulse">
 						<div class="pulse-marker blue" />
-						<h3>Installed for testing</h3>
+						<p>Installed for testing</p>
 					</div>
 				</div>
 			</td>
 			<td class="amount">
-				<h4>{installed.length} interceptor</h4>
+				<p>{installed.length} interceptor</p>
 			</td>
 		</tr>
 
@@ -71,12 +71,12 @@
 				<div class="pulse-container">
 					<div class="status-pulse">
 						<div class="pulse-marker gray" />
-						<h3>Planned</h3>
+						<p>Planned</p>
 					</div>
 				</div>
 			</td>
 			<td class="amount">
-				<h4>{planned.length} interceptor</h4>
+				<p>{planned.length} interceptor</p>
 			</td>
 		</tr>
 
@@ -85,12 +85,12 @@
 				<div class="pulse-container">
 					<div class="status-pulse">
 						<div class="pulse-marker gray" />
-						<h3>Contract signed</h3>
+						<p>Contract signed</p>
 					</div>
 				</div>
 			</td>
 			<td class="amount">
-				<h4>{inMaintenance.length} interceptor</h4>
+				<p>{inMaintenance.length} interceptor</p>
 			</td>
 		</tr>
 	</table>

--- a/src/lib/components/trash-removed.svelte
+++ b/src/lib/components/trash-removed.svelte
@@ -1,34 +1,34 @@
 <script>
-    export let data
-    export let text
+	export let data;
+	export let text;
 </script>
 
 <!-- was box-1 -->
 <section class="trash-removed-total">
-    <h2>{new Intl.NumberFormat().format(data.debris_extracted_total)} KG</h2>
-    <p>{text.dashboard.trashRemoved.total}</p>
+	<span>{new Intl.NumberFormat().format(data.debris_extracted_total)} KG</span>
+	<p>{text.dashboard.trashRemoved.total}</p>
 </section>
 
 <!-- was box-2 -->
 <section class="trash-removed-last-month">
-    <h2>{new Intl.NumberFormat().format(data.debris_extracted_last_30d)} KG</h2>
-    <p>{text.dashboard.trashRemoved.month}</p>
+	<span>{new Intl.NumberFormat().format(data.debris_extracted_last_30d)} KG</span>
+	<p>{text.dashboard.trashRemoved.month}</p>
 </section>
 
 <style>
-    section {
-        border-radius: .5rem;
-        padding: 1.5rem;
-        background-color: var(--trashRemovedBackground);
-        box-shadow: var(--boxShadow) 0px 0px 8px;
-        transition: .2s;
-        /* border: 20px solid var(--lightBlue) */
-    }
-    .trash-removed-total {
-        grid-area: trash-removed-total;
-    }
+	section {
+		border-radius: 0.5rem;
+		padding: 1.5rem;
+		background-color: var(--trashRemovedBackground);
+		box-shadow: var(--boxShadow) 0px 0px 8px;
+		transition: 0.2s;
+		/* border: 20px solid var(--lightBlue) */
+	}
+	.trash-removed-total {
+		grid-area: trash-removed-total;
+	}
 
-    .trash-removed-last-month {
-        grid-area: trash-removed-last-month;
-    }
+	.trash-removed-last-month {
+		grid-area: trash-removed-last-month;
+	}
 </style>


### PR DESCRIPTION
In deze pull request heb ik de headings van de website.(issue 16) Hier zijn de belangrijkste wijzigingen:

**Aanpassingen:**

In het component "system-status" heb ik de heading 3 en 4 vervangen door p-element. In dit geval wordt het h3 en h4 element gebruikt om de toeveelheid interceptors of de naam van de interceptor weer te geven, wat mij juist misplaatst lijkt, gezien dat de tekst niet als een kop (heading) is, maar eerder als een beschrijven van de hoeveelheid of naam.

In het component "trash-removed" heb ik de h3 veranderd naar een span, omdat de getallen niet echt dienen als een kop, maar een span. Het span element is een inline element dat typisch wordt gebruikt voor het toepassen van stijlen op een specifiek.