### PR TITLE
Focus style tab

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -10,6 +10,9 @@
 
 	<script src='https://api.mapbox.com/mapbox-gl-js/v2.9.1/mapbox-gl.js'></script>
 	<link href='https://api.mapbox.com/mapbox-gl-js/v2.9.1/mapbox-gl.css' rel='stylesheet' />
+
+	<!-- CSS -->
+	<link rel="stylesheet" type="text/css" href="%sveltekit.assets%/styles/style.css" />
 	<meta name="viewport" content="width=device-width" />
 	%sveltekit.head%
 </head>

--- a/src/lib/components/navigation.svelte
+++ b/src/lib/components/navigation.svelte
@@ -85,7 +85,6 @@
      box-shadow: var(--boxShadow) 0px 0px 8px;
      z-index: 100;
  }
-
  nav {
      height: 5.5rem;
      display: flex;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,22 +19,6 @@
 		font-family: 'Proxima', sans-serif;
 	}
 
-	:root {
-		--darkBlue: #143653;
-		--lightBlue: #5cc8de;
-		--whiteColor: #ffffff;
-		--lightGray: #f7f7f7;
-		--accentGray: rgb(228, 228, 228);
-		--worldmapGray: #dbdbdb;
-		--worldmapBorder: #8c8c8c;
-		--worldmapbuttons: rgb(235, 235, 235);
-		--textColor: #143653;
-		--boxShadow: rgba(128, 128, 128, 0.132);
-		--color: rgb(212, 212, 212);
-		--textSize: 1.2rem;
-		--iconSize: 2rem;
-	}
-
 	:global(html) {
 		scroll-behavior: smooth;
 	}
@@ -44,4 +28,8 @@
 		color: var(--textColor);
 		position: relative;
 	}	
+	:focus-visible{
+		border: 1rem solid black;
+		background-color: yellow;
+	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -285,19 +285,19 @@
 			padding: 1.5rem;
 		}
 
-		.chart-continents {
-			/* font-size: 3rem; */
+		/* .chart-continents {
+			font-size: 3rem;
 		}
 
 		.chart-river-ocean {
-			/* font-size: 2.5rem; */
+			font-size: 2.5rem;
 		}
 
 		.chart-river-ocean,
 		.chart-continents,
 		h2 {
-			/* font-size: 1.5rem; */
-		}
+			font-size: 1.5rem;
+		} */
 
 		.dashboard-line {
 			height: 2px;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -90,37 +90,6 @@
 		font-family: 'Proxima', sans-serif;
 	}
 
-	:root {
-		--darkBlue: #143653;
-		--trashRemovedBackground: white;
-		--lightBlue: #5cc8de;
-		--whiteColor: #ffffff;
-		--lightGray: #f7f7f7;
-		--accentGray: rgb(228, 228, 228);
-		--textColor: #143653;
-		--boxShadow: rgba(128, 128, 128, 0.132);
-		--color: rgb(212, 212, 212);
-		--textSize: 1.2rem;
-		--iconSize: 2rem;
-	}
-
-	/* Als darkmode de standaard instelling is */
-	@media (prefers-color-scheme: dark) {
-		:root {
-			--darkBlue: #ffffff;
-			--trashRemovedBackground: #143653;
-			--lightBlue: #5cc8de;
-			--whiteColor: #143653;
-			--lightGray: #0d2437;
-			--accentGray: rgb(228, 228, 228);
-			--textColor: #ffffff;
-			--boxShadow: rgba(128, 128, 128, 0);
-			--color: rgb(212, 212, 212);
-			--textSize: 1.2rem;
-			--iconSize: 2rem;
-		}
-	}
-
 	:global(html) {
 		scroll-behavior: smooth;
 	}

--- a/src/routes/interceptor/+page.svelte
+++ b/src/routes/interceptor/+page.svelte
@@ -31,23 +31,6 @@
 </a>
    
 <style>
-
-    /* Als darkmode de standaard instelling is */
-    @media (prefers-color-scheme: dark) {
-        :root {
-        --darkBlue: #ffffff;
-        --lightBlue: #5CC8DE;
-        --whiteColor: #143653;
-        --lightGray: #0D2437;
-        --accentGray: rgb(228, 228, 228);
-        --textColor: #ffffff;
-        --boxShadow: rgba(128, 128, 128, 0.0);
-        --color: rgb(212, 212, 212);
-        --textSize: 1.2rem;
-        --iconSize: 2rem;
-        --trashRemovedBackground: #143653;
-        } 
-    }
     .map {
 		grid-area: map;
 		border-radius: 0.5rem;

--- a/src/routes/oceanSystem/+page.svelte
+++ b/src/routes/oceanSystem/+page.svelte
@@ -34,38 +34,7 @@
 </a>
 
 
-<style>
-        :root {
-            --darkBlue: #143653;
-            --lightBlue: #5CC8DE;
-            --whiteColor: #ffffff;
-            --lightGray: #f7f7f7;
-            --accentGray: rgb(228, 228, 228);
-            --textColor: #143653;
-            --boxShadow: rgba(128, 128, 128, 0.132);
-            --color: rgb(212, 212, 212);
-            --textSize: 1.2rem;
-            --iconSize: 2rem;
-            --trashRemovedBackground: white;
-        }
-            
-        /* Als darkmode de standaard instelling is */
-        @media (prefers-color-scheme: dark) {
-        :root {
-        --darkBlue: #ffffff;
-        --lightBlue: #5CC8DE;
-        --whiteColor: #143653;
-        --lightGray: #0D2437;
-        --accentGray: rgb(228, 228, 228);
-        --textColor: #ffffff;
-        --boxShadow: rgba(128, 128, 128, 0.0);
-        --color: rgb(212, 212, 212);
-        --textSize: 1.2rem;
-        --iconSize: 2rem;
-        --trashRemovedBackground: #143653;
-        } 
-  }
-  
+<style> 
   .map {
 		grid-area: map;
 		border-radius: 0.5rem;

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -1,5 +1,5 @@
 *:focus-visible, button:focus-visible{
-    border: 1rem solid black;
+    border: 3px solid black;
 }
 
 :root {

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -1,7 +1,6 @@
 *:focus-visible, button:focus-visible{
     border: 3px solid black;
 }
-
 :root {
     --darkBlue: #143653;
     --trashRemovedBackground: white;

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -1,0 +1,34 @@
+*:focus-visible, button:focus-visible{
+    border: 1rem solid black;
+}
+
+:root {
+    --darkBlue: #143653;
+    --trashRemovedBackground: white;
+    --lightBlue: #5cc8de;
+    --whiteColor: #ffffff;
+    --lightGray: #f7f7f7;
+    --accentGray: rgb(228, 228, 228);
+    --textColor: #143653;
+    --boxShadow: rgba(128, 128, 128, 0.132);
+    --color: rgb(212, 212, 212);
+    --textSize: 1.2rem;
+    --iconSize: 2rem;
+    --trashRemovedBackground: white;
+}
+@media (prefers-color-scheme: dark) {
+    :root {
+        --darkBlue: #ffffff;
+        --trashRemovedBackground: #143653;
+        --lightBlue: #5cc8de;
+        --whiteColor: #143653;
+        --lightGray: #0d2437;
+        --accentGray: rgb(228, 228, 228);
+        --textColor: #ffffff;
+        --boxShadow: rgba(128, 128, 128, 0);
+        --color: rgb(212, 212, 212);
+        --textSize: 1.2rem;
+        --iconSize: 2rem;
+        --trashRemovedBackground: #143653;
+    }
+}


### PR DESCRIPTION
Ik heb het volgende gedaan:

- Een aparte CSS bestand aangemaakt, met hulp van Michelle is het gelukt deze op de juiste manier te linken aan ons project.
- In dit CSS bestand heb ik een focus-visible style meegegeven voor het tabben. Hierdoor is het nog ietsje duidelijker waar je bent met tabben.
- Ik heb uit alle pagina's de root variabelen en dark mode styling weggehaald en in dit globale CSS bestand gezet. Nu is ons project meer DRY 😎 